### PR TITLE
add PlayerUnitGetTrackbackPositionWithMoveStopMoveKnockback

### DIFF
--- a/client/potato/Assets/Tests.EditMode/TestUnitMove.cs
+++ b/client/potato/Assets/Tests.EditMode/TestUnitMove.cs
@@ -332,4 +332,75 @@ public class UnitMove
             Assert.That(unit1.GetTrackbackPosition(7), Is.AreApproximatelyEqual(new Vector3(1, -1, 0)));
         }
     }
+
+    [Test]
+    public void PlayerUnitGetTrackbackPositionWithMoveStopMoveKnockback()
+    {
+        static PlayerUnit createUnit()
+        {
+            var unit = new PlayerUnit(0, new UnitId(0), Vector3.zero, Potato.UnitDirection.Down, null);
+            unit.InputMove(new MoveCommand
+            {
+                From = Vector3.zero,
+                To = new Vector3(1000, 0, 0),
+                StartTime = 1,
+                Speed = 1,
+            });
+            unit.InputStop(new StopCommand
+            {
+                StopTime = 2,
+            });
+            unit.InputMove(new MoveCommand
+            {
+                From = new Vector3(1, 0, 0),
+                To = new Vector3(1, 1000, 0),
+                StartTime = 3,
+                Speed = 1,
+            });
+            return unit;
+        }
+
+        {
+            PlayerUnit unit1 = createUnit();
+            unit1.Update(0);
+            Assert.That(unit1.Position, Is.AreApproximatelyEqual(Vector3.zero));
+            unit1.Update(1);
+            Assert.That(unit1.Position, Is.AreApproximatelyEqual(Vector3.zero));
+            unit1.Update(2);
+            Assert.That(unit1.Position, Is.AreApproximatelyEqual(new Vector3(1, 0, 0)));
+            unit1.Update(3);
+            Assert.That(unit1.Position, Is.AreApproximatelyEqual(new Vector3(1, 0, 0)));
+            unit1.Update(4);
+            Assert.That(unit1.Position, Is.AreApproximatelyEqual(new Vector3(1, 1, 0)));
+            unit1.Update(5);
+            Assert.That(unit1.Position, Is.AreApproximatelyEqual(new Vector3(1, 2, 0)));
+
+            unit1.InputKnockback(new KnockbackCommand
+            {
+                From = new Vector3(1, 1, 0),
+                To = new Vector3(1, -1000, 0),
+                StartTime = 4,
+                EndTime = 6,
+                Speed = 1,
+            });
+            unit1.InputStop(new StopCommand
+            {
+                StopTime = 6,
+            });
+
+            unit1.Update(6);
+            Assert.That(unit1.Position, Is.AreApproximatelyEqual(new Vector3(1, -1, 0)));
+            unit1.Update(7);
+            Assert.That(unit1.Position, Is.AreApproximatelyEqual(new Vector3(1, -1, 0)));
+
+            Assert.That(unit1.GetTrackbackPosition(0), Is.AreApproximatelyEqual(Vector3.zero));
+            Assert.That(unit1.GetTrackbackPosition(1), Is.AreApproximatelyEqual(Vector3.zero));
+            Assert.That(unit1.GetTrackbackPosition(2), Is.AreApproximatelyEqual(new Vector3(1, 0, 0)));
+            Assert.That(unit1.GetTrackbackPosition(3), Is.AreApproximatelyEqual(new Vector3(1, 0, 0)));
+            Assert.That(unit1.GetTrackbackPosition(4), Is.AreApproximatelyEqual(new Vector3(1, 1, 0)));
+            Assert.That(unit1.GetTrackbackPosition(5), Is.AreApproximatelyEqual(new Vector3(1, 0, 0)));
+            Assert.That(unit1.GetTrackbackPosition(6), Is.AreApproximatelyEqual(new Vector3(1, -1, 0)));
+            Assert.That(unit1.GetTrackbackPosition(7), Is.AreApproximatelyEqual(new Vector3(1, -1, 0)));
+        }
+    }
 }


### PR DESCRIPTION
- split test command and unit, aaand swap actual and expect
- add CalcCurrentPosition and LastMoveCommand to ICommand
- GetTrackbackPosition and fix knockback bug
- add PlayerUnitGetTrackbackPositionWithMoveStopMoveKnockback
