### PR TITLE
スポーンした瞬間に移動中だったユニットの停止コマンドが送信されない不具合修正

### DIFF
--- a/server/action-server3/src/services/game_service_provider.cpp
+++ b/server/action-server3/src/services/game_service_provider.cpp
@@ -590,8 +590,18 @@ void GameServiceProvider::sendSpawnUnit(potato::net::SessionId sessionId, std::s
 				notification.set_move_id(moveCommand->moveId);
 				_nerworkServiceProvider.lock()->sendTo(sessionId, torikime::unit::move::Rpc::serializeNotification(notification));
 			}
+			else
+			{
+				fmt::print("session[{}] unit[{}] call sendSpawnUnit(Send MoveCommand) but MoveCommand is null\n", sessionId, unit->getUnitId());
+				unit->dump(now);
+				assert(false);
+			}
 
 			auto stopCommand = std::dynamic_pointer_cast<StopCommand>(unit->getLastCommand());
+			if (stopCommand == nullptr)
+			{
+				stopCommand = unit->getFirstStopCommandFromQueue();
+			}
 			if (stopCommand != nullptr)
 			{
 				torikime::unit::stop::Notification notification;
@@ -605,6 +615,12 @@ void GameServiceProvider::sendSpawnUnit(potato::net::SessionId sessionId, std::s
 
 				auto payload = torikime::unit::stop::Rpc::serializeNotification(notification);
 				_nerworkServiceProvider.lock()->sendTo(sessionId, payload);
+			}
+			else
+			{
+				fmt::print("session[{}] unit[{}] call sendSpawnUnit(Send StopCommand) but StopCommand is null\n", sessionId, unit->getUnitId());
+				unit->dump(now);
+				assert(false);
 			}
 		}
 	}

--- a/server/action-server3/src/units/unit.cpp
+++ b/server/action-server3/src/units/unit.cpp
@@ -35,6 +35,24 @@ const std::shared_ptr<MoveCommand> Unit::getLastMoveCommand() const
 	return getLastMoveCommand();
 }
 
+std::shared_ptr<StopCommand> Unit::getFirstStopCommandFromQueue()
+{
+	for (auto& input : inputQueue)
+	{
+		if (input->getCommandType() == CommandType::Stop)
+		{
+			return std::dynamic_pointer_cast<StopCommand>(input);
+		}
+	}
+
+	return nullptr;
+}
+
+const std::shared_ptr<StopCommand> Unit::getFirstStopCommandFromQueue() const
+{
+	return getFirstStopCommandFromQueue();
+}
+
 void Unit::inputCommand(std::shared_ptr<ICommand> command)
 {
 	auto stopCommand = std::dynamic_pointer_cast<StopCommand>(command);
@@ -43,7 +61,7 @@ void Unit::inputCommand(std::shared_ptr<ICommand> command)
 		stopCommand->lastMoveCommand = std::dynamic_pointer_cast<MoveCommand>(getLastCommand());
 	}
 
-	inputQueue.emplace(command);
+	inputQueue.emplace_back(command);
 
 	if (command->getCommandType() == CommandType::KnockBack)
 	{
@@ -170,7 +188,7 @@ void Unit::update(int64_t now)
 					break;
 				}
 			}
-			inputQueue.pop();
+			inputQueue.pop_front();
 
 			switch (command->getCommandType())
 			{
@@ -300,4 +318,12 @@ void Unit::setPosition(const Eigen::Vector3f& position)
 	history.emplace_back(stopCommand);
 
 	currentMove.reset();
+}
+
+void Unit::dump(int64_t now) const
+{
+	for (auto& command : history)
+	{
+		fmt::print("CommandType: {}, Expired: {}, ActionTime: {}\n", static_cast<int32_t>(command->getCommandType()), command->isExpired(now), command->getActionTime());
+	}
 }

--- a/server/action-server3/src/units/unit.h
+++ b/server/action-server3/src/units/unit.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <list>
-#include <queue>
+#include <deque>
 #include <memory>
+#include <ostream>
 
 #include "core/configured_eigen.h"
 
@@ -15,7 +16,7 @@
 
 #include "utility/vector_utility.h"
 
-enum class CommandType
+enum class CommandType : int32_t
 {
 	Stop,
 	Move,
@@ -134,8 +135,13 @@ public:
 	void update(int64_t now);
 
 	std::shared_ptr<ICommand> getLastCommand();
+
 	std::shared_ptr<MoveCommand> getLastMoveCommand();
 	const std::shared_ptr<MoveCommand> getLastMoveCommand() const;
+
+	std::shared_ptr<StopCommand> getFirstStopCommandFromQueue();
+	const std::shared_ptr<StopCommand> getFirstStopCommandFromQueue() const;
+
 
 	UnitId getUnitId() const
 	{
@@ -225,6 +231,8 @@ public:
 		_components.erase(typeid(T).hash_code());
 	}
 
+	void dump(int64_t now) const;
+
 private:
 	const UnitId _unitId = UnitId(0);
 	potato::net::SessionId _sessionId = potato::net::SessionId(0);
@@ -233,7 +241,7 @@ private:
 	int32_t _lastLatency = 0;
 	Eigen::Vector3f position = {};
 	std::shared_ptr<MoveCommand> currentMove;
-	std::queue< std::shared_ptr<ICommand>> inputQueue;
+	std::deque< std::shared_ptr<ICommand>> inputQueue;
 	std::list<std::shared_ptr<ICommand>> history;
 	potato::UnitDirection _direction = potato::UNIT_DIRECTION_DOWN;
 	bool _isMoving = false;


### PR DESCRIPTION
closes #144
