### PR TITLE
GameServiceProvider::sendSpawnUnitの送信対象をエリア内のユニットに限定する

### DIFF
--- a/server/action-server3/src/area/area.cpp
+++ b/server/action-server3/src/area/area.cpp
@@ -30,4 +30,9 @@ namespace potato
 	{
 		return _sessionIds;
 	}
+
+	void Area::process(Processor processor)
+	{
+		std::for_each(_units.begin(), _units.end(), processor);
+	}
 }

--- a/server/action-server3/src/area/area.h
+++ b/server/action-server3/src/area/area.h
@@ -26,6 +26,9 @@ namespace potato
 
 		const std::set<potato::net::SessionId> getSessionIds() const;
 
+		using Processor = std::function<void(std::weak_ptr<Unit> weakUnit)>;
+		void process(Processor processor);
+
 	private:
 		const AreaId _areaId;
 		std::list<std::weak_ptr<Unit>> _units;


### PR DESCRIPTION
closes #175
